### PR TITLE
Add minimal hostable MCP Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# mara
+# Hostable MCP Example
+
+This repository contains a simple Flask application that mimics a basic chat panel similar to the features of [same.new](https://same.new/). The app allows you to send prompts to an OpenAI model and view the response in a minimal web interface.
+
+## Features
+- Web-based chat panel using Flask
+- Integration with OpenAI's API via `openai` library
+- Simple HTML interface for sending prompts
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+3. Run the server:
+   ```bash
+   python app.py
+   ```
+4. Open your browser at `http://localhost:5000` to interact with the chat panel.
+
+This example is intentionally minimal and can be extended with additional features such as user authentication, conversation history, and more sophisticated UI elements.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+from flask import Flask, request, jsonify, render_template_string
+import os
+import openai
+
+app = Flask(__name__)
+
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+TEMPLATE = """
+<!doctype html>
+<title>MCP Chat</title>
+<h1>Simple Chat</h1>
+<form action="/chat" method="post">
+  <textarea name="prompt" rows="4" cols="50" placeholder="Enter your prompt here..."></textarea><br>
+  <input type="submit" value="Send">
+</form>
+{% if response %}
+<h2>Response:</h2>
+<pre>{{ response }}</pre>
+{% endif %}
+"""
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template_string(TEMPLATE)
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    prompt = request.form.get('prompt', '')
+    if not prompt:
+        return render_template_string(TEMPLATE, response='No prompt provided.')
+    try:
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        reply = completion.choices[0].message['content']
+    except Exception as e:
+        reply = f"Error: {e}"
+    return render_template_string(TEMPLATE, response=reply)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai


### PR DESCRIPTION
## Summary
- add simple Flask app to mimic a basic chat panel similar to `same.new`
- document usage in README
- add requirements file and gitignore

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e0814c6c83289ad3b56188b19e02